### PR TITLE
Adicao da permissao CORS e url de oarquivos

### DIFF
--- a/ApiIFPBProfessoresTSI/settings.py
+++ b/ApiIFPBProfessoresTSI/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'ApiIFPBProfessoresTSI.api',
     'rest_framework',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
@@ -55,6 +56,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
 ]
 
 ROOT_URLCONF = 'ApiIFPBProfessoresTSI.urls'
@@ -127,9 +129,10 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-# You also need to add the following settings to specify where the uploaded files will be saved and from which URL they can be served:
+# You also need to add the following settings to specify where the uploaded
+# files will be saved and from which URL they can be served:
 
-MEDIA_URL =  '/media/'
+MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 
@@ -137,6 +140,8 @@ STATIC_DIRS = (
     os.path.join(os.path.abspath(os.path.dirname(__file__) + '/..'), 'static'),
 )
 
+# Cors configuration
+CORS_ORIGIN_ALLOW_ALL = True
 
 # Configure Django App for Heroku.
 django_heroku.settings(locals())

--- a/ApiIFPBProfessoresTSI/urls.py
+++ b/ApiIFPBProfessoresTSI/urls.py
@@ -17,6 +17,9 @@ from django.contrib import admin
 from django.urls import path,include
 from rest_framework import routers
 from .api import views
+from django.conf.urls.static import static
+from django.conf import settings
+
 
 router = routers.DefaultRouter()
 router.register(r'professores', views.ProfessorViewSet)
@@ -25,7 +28,9 @@ urlpatterns = [
     path('', include(router.urls)),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('admin/', admin.site.urls),
-] 
+]
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 # + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 # urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Usado o django-cors-headers para controle do CORS e adicionada as urls estaticas e de media.